### PR TITLE
OP-1437: Block saving/editing historical data

### DIFF
--- a/medical_pricelist/gql_mutations.py
+++ b/medical_pricelist/gql_mutations.py
@@ -70,6 +70,8 @@ def create_or_update_pricelist(
 
     if pricelist_uuid:
         pricelist = pricelist_model.objects.get(uuid=pricelist_uuid)
+        if pricelist.validity_to:
+            raise ValidationError("User can not edit historical data")
         for (key, value) in data.items():
             setattr(pricelist, key, value)
     else:


### PR DESCRIPTION
[OP-1437](https://openimis.atlassian.net/browse/OP-1437)

RELATED [FE PR](https://github.com/openimis/openimis-fe-medical_pricelist_js/pull/33)

Changes:
- Do not let to save/edit historical data.

[OP-1437]: https://openimis.atlassian.net/browse/OP-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ